### PR TITLE
Add Streamlit UI for Salesforce and Tubular merges

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ With custom header mapping:
 python merge_no_api.py --opps opps.csv --map channel_map.csv --metrics tubular.csv --metrics-cols channel_id:Channel ID,views_30d:Views (30d),audience_size:Subscribers --out merged.csv
 ```
 
+## Interactive UI
+
+Launch the Streamlit workspace to upload CSV exports and download the merged output without
+using the command line:
+
+```bash
+streamlit run streamlit_app.py
+```
+
+The app previews your inputs, highlights how many opportunities matched Tubular data, and lets
+you download the merged CSV directly from the browser.
+
 ## Output
 
 Produces **merged.csv** with Salesforce Opps + Tubular metrics.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pandas
+streamlit

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,115 @@
+"""Streamlit UI for merging Salesforce opportunities with Tubular metrics."""
+from typing import Optional
+
+import pandas as pd
+import streamlit as st
+
+from merge_no_api import merge_data, parse_colmap
+
+st.set_page_config(page_title="Salesforce + Tubular Merge", layout="wide")
+
+st.title("Salesforce ↔ Tubular Merge Workbench")
+st.markdown(
+    "Use this tool to combine a Salesforce opportunity export with Tubular channel metrics."
+)
+
+with st.expander("How it works"):
+    st.markdown(
+        """
+        1. Export your Salesforce opportunities as CSV (include **Account.Name** and, if possible, the
+           YouTube channel ID field).
+        2. Export the relevant Tubular metrics as CSV. Make sure there is a **channel_id** column or
+           provide the mapping in the *Metrics header mapping* field below.
+        3. (Optional) Upload a channel map when the opportunity file does not contain a channel ID.
+        4. Click **Merge data** to preview and download the combined dataset.
+        """
+    )
+
+opps_file = st.file_uploader("Salesforce opportunities CSV", type="csv", key="opps")
+map_file = st.file_uploader(
+    "Channel map CSV (optional)",
+    type="csv",
+    help="Use when your opportunities do not include a channel_id column. Must contain account_name, channel_id.",
+)
+metrics_file = st.file_uploader("Tubular metrics CSV", type="csv", key="metrics")
+
+metrics_mapping = st.text_input(
+    "Metrics header mapping (optional)",
+    value="",
+    placeholder="channel_id:Channel ID,views_30d:Views (30d),audience_size:Subscribers",
+    help="Provide comma-separated pairs of expected_header:your_csv_header when Tubular columns use different labels.",
+)
+
+preview_toggle = st.checkbox("Show input previews", value=False)
+
+opps_df: Optional[pd.DataFrame] = None
+map_df: Optional[pd.DataFrame] = None
+metrics_df: Optional[pd.DataFrame] = None
+colmap = None
+
+if preview_toggle and opps_file is not None:
+    opps_df = pd.read_csv(opps_file)
+    st.caption("Opportunities preview")
+    st.dataframe(opps_df.head())
+else:
+    if opps_file is not None:
+        opps_df = pd.read_csv(opps_file)
+
+if preview_toggle and map_file is not None:
+    map_df = pd.read_csv(map_file)
+    st.caption("Channel map preview")
+    st.dataframe(map_df.head())
+else:
+    if map_file is not None:
+        map_df = pd.read_csv(map_file)
+
+if preview_toggle and metrics_file is not None:
+    metrics_df = pd.read_csv(metrics_file)
+    st.caption("Tubular metrics preview")
+    st.dataframe(metrics_df.head())
+else:
+    if metrics_file is not None:
+        metrics_df = pd.read_csv(metrics_file)
+
+if metrics_mapping:
+    try:
+        colmap = parse_colmap(metrics_mapping)
+    except ValueError as exc:
+        st.error(str(exc))
+        colmap = None
+
+merge_button_disabled = opps_df is None or metrics_df is None or (metrics_mapping and colmap is None)
+
+merge_clicked = st.button("Merge data", disabled=merge_button_disabled)
+
+if merge_clicked:
+    if opps_df is None or metrics_df is None:
+        st.error("Upload both the Salesforce opportunities file and the Tubular metrics file.")
+    else:
+        try:
+            merged = merge_data(opps_df, metrics_df, map_df=map_df, metrics_colmap=colmap)
+        except ValueError as exc:
+            st.error(str(exc))
+        else:
+            st.success(
+                f"Merged {len(merged)} opportunities using channel column "
+                f"`{merged.attrs.get('channel_column', 'channel_id')}`."
+            )
+
+            metrics_missing = merged["channel_name"].isna().sum() if "channel_name" in merged.columns else 0
+            map_used = merged.attrs.get("map_used", False)
+
+            info_cols = st.columns(3)
+            info_cols[0].metric("Total rows", len(merged))
+            info_cols[1].metric("Missing Tubular matches", metrics_missing)
+            info_cols[2].metric("Used channel map", "Yes" if map_used else "No")
+
+            st.dataframe(merged.head(100))
+
+            csv_bytes = merged.to_csv(index=False).encode("utf-8")
+            st.download_button(
+                "Download merged CSV",
+                data=csv_bytes,
+                file_name="merged.csv",
+                mime="text/csv",
+            )


### PR DESCRIPTION
## Summary
- refactor the CLI merge script to expose reusable `merge_data` logic and richer error handling
- add a Streamlit workbench for uploading Salesforce, Tubular, and channel map CSVs and downloading the merged result
- document the interactive UI workflow and add Streamlit to the Python dependencies

## Testing
- python merge_no_api.py --opps sample_opps.csv --metrics sample_tubular.csv --out merged.csv
- pip install -r requirements.txt *(fails: unable to reach PyPI due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68dc312267fc83318da0497cb85d7c58